### PR TITLE
Resere register r14 for signal restore mechanism

### DIFF
--- a/gcc/config/i386/nacl.h
+++ b/gcc/config/i386/nacl.h
@@ -239,7 +239,7 @@ Boston, MA 02111-1307, USA.  */
 /* mm0, mm1, mm2, mm3, mm4, mm5, mm6, mm7*/			\
      0,   0,   0,   0,   0,   0,   0,   0,			\
 /*  r8,  r9, r10, r11, r12, r13, r14, r15*/			\
-     2,   2,   2,   2,   2,   2,   2,   1,			\
+     2,   2,   2,   2,   2,   2,   1,   1,			\
 /*xmm8,xmm9,xmm10,xmm11,xmm12,xmm13,xmm14,xmm15*/		\
      2,   2,    2,    2,    2,    2,    2,    2 }
 #undef CALL_USED_REGISTERS
@@ -253,7 +253,7 @@ Boston, MA 02111-1307, USA.  */
 /* mm0, mm1, mm2, mm3, mm4, mm5, mm6, mm7*/			\
      1,   1,   1,   1,   1,   1,   1,   1,			\
 /*  r8,  r9, r10, r11, r12, r13, r14, r15*/			\
-     1,   1,   1,   1,   2,   2,   2,   1,			\
+     1,   1,   1,   1,   2,   2,   1,   1,			\
 /*xmm8,xmm9,xmm10,xmm11,xmm12,xmm13,xmm14,xmm15*/		\
      1,   1,    1,    1,    1,    1,    1,    1 }
 /* Leave is forbidden in NaCl mode */


### PR DESCRIPTION
This change is needed so we can properly restore from signal handlers

via the note in NaCl for TrampolineRegRestore

```
 * This function's address is put onto the stack immediately under the signal handler's stack frame such that it is called
 * as soon as the untrusted signal handler returns. This function is loaded into the trampoline at NaClPatchRegTrampolineCall
 * called from sel_ldr.c, and lives in cage memory. First it calls into another trampoline entry for NaClSysSigmaskSigreturn
 * which resets the sigprocmask of the thread which was set by sigaction, and also unsets some natp bookkeeping.
 *
 * After that it restores all registers to the values they should be in untrusted. However this created an issue--
 * when we wanted to restore to the previous untrusted state we had to be at a point where every register contains
 * the correct value for the untrusted state except for the instruction pointer. The question then arises, where is
 * the instruction pointer to be restored from? The answer is either a static address, on the untrusted stack, a fixed
 * trusted address, or nowhere. It may be possible to store some sort of protected thread local stack data structure
 * for addreses of received signals but as the fixed trusted address can't handle multiple signals called on top of
 * each other and the untrusted address leaves us very vulnerable to TOCTTOUs, we decided that we had little choice
 * but to reserve the r14 register expressly for this purpose--any use of it within untrusted code is undefined.
 * The rip and rsp values are importantly masked to 32 byte aligned addresses, see the comment at the top of
 * linux/nacl_signal.c for more information, and the flags register is masked on the stack although this is pretty useless
 * We make sure to restore the flags as it's crucial that things like OF and SF are restored.

```